### PR TITLE
Add Register Page POM and Last name test cases

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,15 +39,15 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
 
     /* Test against mobile viewports. */
     // {

--- a/src/pages/registrationPage.ts
+++ b/src/pages/registrationPage.ts
@@ -1,6 +1,7 @@
 import { expect, type Locator, type Page } from "@playwright/test";
+import { generateUniqueEmail, TestData } from "../testData/testData";
 
-export class registerPage {
+export class RegisterPage {
   readonly page: Page;
   readonly firstnameInput: Locator;
   readonly lastnameInput: Locator;
@@ -55,18 +56,18 @@ export class registerPage {
     await this.page.keyboard.press("Tab");
   }
 
-  async fillRequiredFieldsExcept(skipField: 'firstname' | 'lastname' | null = null): Promise<void> {  //for select which field will be empty
+  async fillRequiredFieldsExcept(skipField?: 'firstname' | 'lastname'): Promise<void> {  //for select which field will be empty
     if(skipField !== 'firstname') {
-        await this.firstnameInput.fill('TestFirstName') 
+        await this.firstnameInput.fill(TestData.FIRSTNAME) 
     }
     if(skipField !== 'lastname') {
-        await this.lastnameInput.fill('TestLastname')
+        await this.lastnameInput.fill(TestData.LASTNAME)
     }
     
-    await this.emailInput.fill(`testzi${Date.now()}@mail.com`);  //for make email address unique
-    await this.passwordInput.fill("Test1234!");
-    await this.confirmPasswordInput.fill("Test1234!");
-    await this.dateOfBirthInput.fill("2000-01-01");
+    await this.emailInput.fill(generateUniqueEmail());  
+    await this.passwordInput.fill(TestData.PASSWORD);
+    await this.confirmPasswordInput.fill(TestData.PASSWORD);
+    await this.dateOfBirthInput.fill(TestData.DATE_OF_BIRTH);
   }
 
 }

--- a/src/pages/registrationPage.ts
+++ b/src/pages/registrationPage.ts
@@ -1,0 +1,72 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export class registerPage {
+  readonly page: Page;
+  readonly firstnameInput: Locator;
+  readonly lastnameInput: Locator;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly confirmPasswordInput: Locator;
+  readonly dateOfBirthInput: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.firstnameInput = page.locator("input[name='firstName']");
+    this.lastnameInput = page.locator("input[name='lastName']");
+    this.emailInput = page.locator('input[name="email"]');
+    this.passwordInput = page.locator('input[name="password"]');
+    this.confirmPasswordInput = page.locator('input[name="passwordConfirmation"]');
+    this.dateOfBirthInput = page.locator('input[name="dateOfBirth"]');
+    this.submitButton = page.locator("button[type='submit']");
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("https://qa-course-01.andersenlab.com/registration");
+  }
+
+  async fillFirstname(firstname: string): Promise<void> {
+    await this.firstnameInput.fill(firstname);
+  }
+
+  async fillLastname(lastname: string): Promise<void> {
+    await this.lastnameInput.fill(lastname);
+  }
+
+  async submit(): Promise<void> {
+    await this.submitButton.click();
+  }
+
+  async fillEmail(email: string): Promise<void> {
+    await this.emailInput.fill(email);
+  }
+
+  async fillPassword(password: string): Promise<void> {
+    await this.passwordInput.fill(password);
+  }
+
+  async fillConfirmPassword(password: string): Promise<void> {
+    await this.confirmPasswordInput.fill(password);
+  }
+
+
+  async fillDateOfBirth(dateOfBirth: string): Promise<void> {
+    await this.dateOfBirthInput.fill(dateOfBirth);
+    await this.page.keyboard.press("Tab");
+  }
+
+  async fillRequiredFieldsExcept(skipField: 'firstname' | 'lastname' | null = null): Promise<void> {  //for select which field will be empty
+    if(skipField !== 'firstname') {
+        await this.firstnameInput.fill('TestFirstName') 
+    }
+    if(skipField !== 'lastname') {
+        await this.lastnameInput.fill('TestLastname')
+    }
+    
+    await this.emailInput.fill(`testzi${Date.now()}@mail.com`);  //for make email address unique
+    await this.passwordInput.fill("Test1234!");
+    await this.confirmPasswordInput.fill("Test1234!");
+    await this.dateOfBirthInput.fill("2000-01-01");
+  }
+
+}

--- a/src/testData/testData.ts
+++ b/src/testData/testData.ts
@@ -5,5 +5,6 @@ export enum TestData {
   DATE_OF_BIRTH = "2000-01-01",
 }
 
-export const generateUniqueEmail = () =>    //for make email address unique (not added testdata because it is not fixed)
-  `testzi${Date.now()}@mail.com`;
+export const generateUniqueEmail = (): string =>  {    //for make email address unique (not added testdata because it is not fixed)
+return `testzi${Date.now()}@mail.com`;
+}  

--- a/src/testData/testData.ts
+++ b/src/testData/testData.ts
@@ -1,0 +1,9 @@
+export enum TestData {
+  FIRSTNAME = "TestFirstName",
+  LASTNAME = "TestLastName",
+  PASSWORD = "Test1234!",
+  DATE_OF_BIRTH = "2000-01-01",
+}
+
+export const generateUniqueEmail = () =>    //for make email address unique (not added testdata because it is not fixed)
+  `testzi${Date.now()}@mail.com`;

--- a/tests/registration/lastname.spec.ts
+++ b/tests/registration/lastname.spec.ts
@@ -10,7 +10,7 @@ test.describe("Last name Suite", () => {
     await register.fillRequiredFieldsExcept("lastname");
   });
 
-  test("AQAPRACT-514 Register with max Last name length (255 characters)", async ({
+  test("[AQAPRACT-514] Register with max Last name length (255 characters)", async ({
     page,
   }) => {
     const maxLength = "A".repeat(255);
@@ -21,7 +21,7 @@ test.describe("Last name Suite", () => {
     await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
   });
 
-  test("AQAPRACT-515 Register with min Last name length (1 character)", async ({
+  test("[AQAPRACT-515] Register with min Last name length (1 character)", async ({
     page,
   }) => {
     await register.fillLastname("A");
@@ -31,7 +31,7 @@ test.describe("Last name Suite", () => {
     await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
   });
 
-  test("AQAPRACT-516 Register with max+1 Last name length (256 characters)", async ({
+  test("[AQAPRACT-516] Register with max+1 Last name length (256 characters)", async ({
     page,
   }) => {
     const aboveMaxLength = "A".repeat(256);
@@ -46,14 +46,14 @@ test.describe("Last name Suite", () => {
     ).toBeVisible();
   });
 
-  test("AQAPRACT-517 Register with empty Last name field", async () => {
+  test("[AQAPRACT-517] Register with empty Last name field", async () => {
     await register.fillLastname("");
     await expect(register.lastnameInput).toHaveValue("");
 
     await expect(register.submitButton).toBeDisabled();
   });
 
-  test("AQAPRACT-518 Register with spaces in Last name field", async ({
+  test("[AQAPRACT-518] Register with spaces in Last name field", async ({
     page,
   }) => {
     await register.fillLastname("   ");

--- a/tests/registration/lastname.spec.ts
+++ b/tests/registration/lastname.spec.ts
@@ -1,0 +1,15 @@
+// import { expect, test } from '@playwright/test';
+// import { registerPage } from '../../src/pages/registrationPage';
+
+// test.describe('Last name Suite', () =>{
+
+//     test.beforeEach(async({page}) =>{
+//         const register = new registerPage(page);
+//         register.goto();
+//         await register.fillRequiredFieldsExcept('lastname');
+//     })
+
+//     test('[AQAPRACT-514]: Register with max Last name length (255 characters)', async({page}) =>{
+//         const register = new registerPage(page);
+//     })
+// })

--- a/tests/registration/lastname.spec.ts
+++ b/tests/registration/lastname.spec.ts
@@ -1,17 +1,18 @@
 import { expect, test } from "@playwright/test";
-import { registerPage } from "../../src/pages/registrationPage";
+import { RegisterPage } from "../../src/pages/registrationPage";
 
 test.describe("Last name Suite", () => {
+  let register: RegisterPage;
+
   test.beforeEach(async ({ page }) => {
-    const register = new registerPage(page);
-    register.goto();
+    register = new RegisterPage(page);
+    await register.goto();
     await register.fillRequiredFieldsExcept("lastname");
   });
 
-  test("[AQAPRACT-514]: Register with max Last name length (255 characters)", async ({
+  test("AQAPRACT-514 Register with max Last name length (255 characters)", async ({
     page,
   }) => {
-    const register = new registerPage(page);
     const maxLength = "A".repeat(255);
 
     await register.fillLastname(maxLength);
@@ -20,10 +21,9 @@ test.describe("Last name Suite", () => {
     await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
   });
 
-  test("[AQAPRACT-515]: Register with min Last name length (1 character)", async ({
+  test("AQAPRACT-515 Register with min Last name length (1 character)", async ({
     page,
   }) => {
-    const register = new registerPage(page);
     await register.fillLastname("A");
     await expect(register.lastnameInput).toHaveValue("A");
 
@@ -31,11 +31,9 @@ test.describe("Last name Suite", () => {
     await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
   });
 
-
-  test("[AQAPRACT-516]: Register with max+1 Last name length (256 characters)", async ({
+  test("AQAPRACT-516 Register with max+1 Last name length (256 characters)", async ({
     page,
   }) => {
-    const register = new registerPage(page);
     const aboveMaxLength = "A".repeat(256);
 
     await register.fillLastname(aboveMaxLength);
@@ -48,22 +46,20 @@ test.describe("Last name Suite", () => {
     ).toBeVisible();
   });
 
+  test("AQAPRACT-517 Register with empty Last name field", async () => {
+    await register.fillLastname("");
+    await expect(register.lastnameInput).toHaveValue("");
 
-  test('[AQAPRACT-517]: Register with empty Last name field', async({page}) => {
-        const register = new registerPage(page);
-        await register.fillLastname('');
-        await expect(register.lastnameInput).toHaveValue(''); 
+    await expect(register.submitButton).toBeDisabled();
+  });
 
-        await expect(register.submitButton).toBeDisabled();
-    });
-
-    test('[AQAPRACT-518]: Register with spaces in Last name field', async({page}) =>{
-        const register = new registerPage(page);
-        await register.fillLastname('   ');
-        await expect(register.lastnameInput).toHaveValue('   ');
-        await register.submit();
-        await expect(page.locator('text=The field is required.')).toBeVisible();
-        await expect(register.lastnameInput).toHaveClass(/border-rose-500/);
-
-    })
+  test("AQAPRACT-518 Register with spaces in Last name field", async ({
+    page,
+  }) => {
+    await register.fillLastname("   ");
+    await expect(register.lastnameInput).toHaveValue("   ");
+    await register.submit();
+    await expect(page.locator("text=The field is required.")).toBeVisible();
+    await expect(register.lastnameInput).toHaveClass(/border-rose-500/);
+  });
 });

--- a/tests/registration/lastname.spec.ts
+++ b/tests/registration/lastname.spec.ts
@@ -1,15 +1,69 @@
-// import { expect, test } from '@playwright/test';
-// import { registerPage } from '../../src/pages/registrationPage';
+import { expect, test } from "@playwright/test";
+import { registerPage } from "../../src/pages/registrationPage";
 
-// test.describe('Last name Suite', () =>{
+test.describe("Last name Suite", () => {
+  test.beforeEach(async ({ page }) => {
+    const register = new registerPage(page);
+    register.goto();
+    await register.fillRequiredFieldsExcept("lastname");
+  });
 
-//     test.beforeEach(async({page}) =>{
-//         const register = new registerPage(page);
-//         register.goto();
-//         await register.fillRequiredFieldsExcept('lastname');
-//     })
+  test("[AQAPRACT-514]: Register with max Last name length (255 characters)", async ({
+    page,
+  }) => {
+    const register = new registerPage(page);
+    const maxLength = "A".repeat(255);
 
-//     test('[AQAPRACT-514]: Register with max Last name length (255 characters)', async({page}) =>{
-//         const register = new registerPage(page);
-//     })
-// })
+    await register.fillLastname(maxLength);
+    await expect(register.lastnameInput).toHaveValue(maxLength);
+    await register.submit();
+    await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
+  });
+
+  test("[AQAPRACT-515]: Register with min Last name length (1 character)", async ({
+    page,
+  }) => {
+    const register = new registerPage(page);
+    await register.fillLastname("A");
+    await expect(register.lastnameInput).toHaveValue("A");
+
+    await register.submit();
+    await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
+  });
+
+
+  test("[AQAPRACT-516]: Register with max+1 Last name length (256 characters)", async ({
+    page,
+  }) => {
+    const register = new registerPage(page);
+    const aboveMaxLength = "A".repeat(256);
+
+    await register.fillLastname(aboveMaxLength);
+    await expect(register.lastnameInput).toHaveValue(aboveMaxLength);
+
+    await register.submit();
+    await expect(register.lastnameInput).toHaveClass(/border-rose-500/);
+    await expect(
+      page.locator("text=The value length shouldn't exceed 255 symbols")
+    ).toBeVisible();
+  });
+
+
+  test('[AQAPRACT-517]: Register with empty Last name field', async({page}) => {
+        const register = new registerPage(page);
+        await register.fillLastname('');
+        await expect(register.lastnameInput).toHaveValue(''); 
+
+        await expect(register.submitButton).toBeDisabled();
+    });
+
+    test('[AQAPRACT-518]: Register with spaces in Last name field', async({page}) =>{
+        const register = new registerPage(page);
+        await register.fillLastname('   ');
+        await expect(register.lastnameInput).toHaveValue('   ');
+        await register.submit();
+        await expect(page.locator('text=The field is required.')).toBeVisible();
+        await expect(register.lastnameInput).toHaveClass(/border-rose-500/);
+
+    })
+});


### PR DESCRIPTION
1. Implemented registerPage class using Page Object Model (POM) approach.
2. Added locators and helper methods for:
- Firstname
- Lastname
- Email
- Password
- Confirm Password
- Date of Birth
- Submit button

2. Implemented method fillRequiredFields(...) to handle required field filling with support for skipping firstname or lastname. 

3. Automated the following Last name test cases:
- AQAPRACT-514: Register with max Last name length (255 characters)
- AQAPRACT-515: Register with min Last name length (1 character)
- AQAPRACT-516: Register with max+1 Last name length (256 characters, validation error)
- AQAPRACT-517: Register with empty Last name field
- AQAPRACT-518: Register with spaces in Last name field

