### PR TITLE
Rafactoring/Fixtures(Register, Sign in, User Profile)

### DIFF
--- a/src/fixtures/fixture_register.ts
+++ b/src/fixtures/fixture_register.ts
@@ -1,0 +1,15 @@
+import { test as base, type Page } from "@playwright/test";
+import { RegisterPage } from "../pages/registrationPage";
+
+type MyFixtures = {
+  page: Page;
+  registerPage: RegisterPage;
+};
+
+export const test = base.extend<MyFixtures>({
+  registerPage: async ({ page }, use) => {
+    const registerPage = new RegisterPage(page);
+    await use(registerPage);
+  },
+
+});

--- a/src/fixtures/fixture_signIn.ts
+++ b/src/fixtures/fixture_signIn.ts
@@ -1,0 +1,21 @@
+import { test as base, type Page} from '@playwright/test';
+import { SignInPage } from '../pages/signInPage';
+import { UserProfilePage } from '../pages/userProfilePage';
+
+type MyFixtures = {
+    page: Page;
+    signInPage: SignInPage;
+    userProfilePage: UserProfilePage;
+}
+
+export const test = base.extend<MyFixtures>({
+    signInPage: async({page}, use) => {
+        const signInpage = new SignInPage(page);
+        await use(signInpage);
+    },
+
+    userProfilePage: async({page}, use) => {
+        const userProfilePage = new UserProfilePage(page);
+        use(userProfilePage);
+    },
+})

--- a/tests/registration/calendar.spec.ts
+++ b/tests/registration/calendar.spec.ts
@@ -1,68 +1,66 @@
-import { expect, test } from "@playwright/test";
-import { RegisterPage } from "../../src/pages/registrationPage";
+import { expect } from "@playwright/test";
+import { test } from "../../src/fixtures/fixture_register";
 
 test.describe("Calendar Suite", () => {
-  let register: RegisterPage;
 
-  test.beforeEach(async ({ page }) => {
-    register = new RegisterPage(page);
-    await register.goto();
-    await register.openCalendar();
+  test.beforeEach(async ({ registerPage }) => {
+    await registerPage.goto();
+    await registerPage.openCalendar();
   });
 
 
-  test("[AQAPRACT-745] Month navigators switch months", async ({ page }) => {
-    const currentMonth = await register.dateCalendar.textContent();
+  test("[AQAPRACT-745] Month navigators switch months", async ({ registerPage }) => {
+    const currentMonth = await registerPage.dateCalendar.textContent();
 
-    await register.nextMonthButton.click();
-    const nextMonth = await register.dateCalendar.textContent();
+    await registerPage.nextMonthButton.click();
+    const nextMonth = await registerPage.dateCalendar.textContent();
 
     expect(nextMonth).not.toEqual(currentMonth);
 
-    await register.prevMonthButton.click();
-    const backToCurrentMonth = await register.dateCalendar.textContent();
+    await registerPage.prevMonthButton.click();
+    const backToCurrentMonth = await registerPage.dateCalendar.textContent();
     expect(backToCurrentMonth).toEqual(currentMonth);
   });
 
 
   test("[AQAPRACT-746] Year drop down is possible to be opened", async ({
-    page,
+    registerPage
   }) => {
-    await register.yearDropdown.click();
-    await register.yearDropdown.selectOption("1900");
+    await registerPage.yearDropdown.click();
+    await registerPage.yearDropdown.selectOption("1900");
 
-    await expect(register.yearDropdown).toHaveValue("1900"); // means we scrool for 1900 option
+    await expect(registerPage.yearDropdown).toHaveValue("1900"); // means we scrool for 1900 option
   });
 
 
-  test("[AQAPRACT-747] Year is possible to be selected", async () => {
+  test("[AQAPRACT-747] Year is possible to be selected", async ({registerPage}) => {
     const targetYear = "2000";
-    await register.yearDropdown.selectOption(targetYear);
-    await expect(register.yearDropdown).toHaveValue(targetYear);
+    await registerPage.yearDropdown.selectOption(targetYear);
+    await expect(registerPage.yearDropdown).toHaveValue(targetYear);
   });
 
 
-  test("[AQAPRACT-748] Month dropdown is possible to be opened", async () => {
-    await register.monthDropdown.click();
-    await register.monthDropdown.selectOption("October");
-    await expect(register.monthDropdown).toHaveValue("October");
+  test("[AQAPRACT-748] Month dropdown is possible to be opened", async ({registerPage}) => {
+    await registerPage.monthDropdown.click();
+    await registerPage.monthDropdown.selectOption("October");
+    await expect(registerPage.monthDropdown).toHaveValue("October");
   });
 
 
-  test("[AQAPRACT-749] Month is possible to be selected", async () => {
+  test("[AQAPRACT-749] Month is possible to be selected", async ({registerPage}) => {
     const targetMonth = "October"; 
-    await register.monthDropdown.selectOption(targetMonth);
-    await expect(register.monthDropdown).toHaveValue(targetMonth);
+    await registerPage.monthDropdown.selectOption(targetMonth);
+    await expect(registerPage.monthDropdown).toHaveValue(targetMonth);
   });
 
 
-  test("[AQAPRACT-750] The date is possible to be selected", async () => {
-    await register.selectYear('1990');
-    await register.selectMonth('October');
-    await register.selectDay("16");
+  test("[AQAPRACT-750] The date is possible to be selected", async ({registerPage}) => {
+    await registerPage.selectYear('1990');
+    await registerPage.selectMonth('October');
+    await registerPage.selectDay("16");
 
-    await expect(register.dateOfBirthInput).toHaveValue("03/15/1990");
-    await expect(register.dateCalendar).not.toBeVisible();             // Should close automatically
+    await expect(registerPage.dateOfBirthInput).toHaveValue("03/15/1990");
+    await expect(registerPage.dateCalendar).not.toBeVisible();             // Should close automatically
   });
 
 });

--- a/tests/registration/dateOfBirth.spec.ts
+++ b/tests/registration/dateOfBirth.spec.ts
@@ -1,58 +1,55 @@
-import { expect, test } from "@playwright/test";
-import { RegisterPage } from "../../src/pages/registrationPage";
+import { expect } from "@playwright/test";
+import { test } from '../../src/fixtures/fixture_register';
 import { generateUniqueEmail, TestData } from "../../src/testData/testData";
 
 test.describe("Date of Birth Suite", () => {
-  let register: RegisterPage;
-
-  test.beforeEach(async ({ page }) => {
-    register = new RegisterPage(page);
-    await register.goto();
-    await register.fillDateOfBirth("");
-    await register.fillFirstname(TestData.FIRSTNAME);
-    await register.fillLastname(TestData.LASTNAME);
-    await register.fillPassword(TestData.PASSWORD);
-    await register.fillConfirmPassword(TestData.PASSWORD);
-    await register.fillEmailInput(generateUniqueEmail());
+  test.beforeEach(async ({ registerPage }) => {
+    await registerPage.goto();
+    await registerPage.fillDateOfBirth("");
+    await registerPage.fillFirstname(TestData.FIRSTNAME);
+    await registerPage.fillLastname(TestData.LASTNAME);
+    await registerPage.fillPassword(TestData.PASSWORD);
+    await registerPage.fillConfirmPassword(TestData.PASSWORD);
+    await registerPage.fillEmailInput(generateUniqueEmail());
   });
 
   test('[AQAPRACT-519] Register with empty "Date of birth" field', async ({
-    page,
+   registerPage
   }) => {
-    await register.fillDateOfBirth("");
-    await expect(register.dateOfBirthInput).toHaveValue("");
-    await expect(register.submitButton).toBeDisabled();
+    await registerPage.fillDateOfBirth("");
+    await expect(registerPage.dateOfBirthInput).toHaveValue("");
+    await expect(registerPage.submitButton).toBeDisabled();
   });
 
   test("[AQAPRACT-520] The elements on the calendar picker are available", async ({
-    page,
+   registerPage
   }) => {
-    await register.openCalendar();
+    await registerPage.openCalendar();
 
     // Check dropdowns visible
-    await expect(register.yearDropdown).toBeVisible();
-    await expect(register.monthDropdown).toBeVisible();
+    await expect(registerPage.yearDropdown).toBeVisible();
+    await expect(registerPage.monthDropdown).toBeVisible();
 
-    await expect(register.dayOption.first()).toBeVisible(); // Check day elements visible
-    await register.selectDate("2000", "January", "15"); // Select any date
-    await expect(register.dateOfBirthInput).toHaveValue("01/15/2000"); // Verify input value (input format: MM/DD/YYYY)
+    await expect(registerPage.dayOption.first()).toBeVisible(); // Check day elements visible
+    await registerPage.selectDate("2000", "January", "15"); // Select any date
+    await expect(registerPage.dateOfBirthInput).toHaveValue("01/15/2000"); // Verify input value (input format: MM/DD/YYYY)
   });
 
   test('[AQAPRACT-521] The date is filled in manually in the "Date of birth" field', async ({
-    page,
+    registerPage
   }) => {
-    await register.openCalendar();
-    await expect(register.dateCalendar).toBeVisible();
+    await registerPage.openCalendar();
+    await expect(registerPage.dateCalendar).toBeVisible();
 
     const manualDate = "01/15/2000";
-    await register.enterDateOfBirthManually(manualDate);
-    await expect(register.dateOfBirthInput).toHaveValue(manualDate);
+    await registerPage.enterDateOfBirthManually(manualDate);
+    await expect(registerPage.dateOfBirthInput).toHaveValue(manualDate);
   });
 
   test('[AQAPRACT-522] It`s impossible to register with the "date of birth" in the future', async ({
-    page,
+    registerPage
   }) => {
-    await register.openCalendar();
+    await registerPage.openCalendar();
 
     // Future data preparation
     const futureDate = new Date();
@@ -62,7 +59,7 @@ test.describe("Date of Birth Suite", () => {
     const day = futureDate.getDate().toString().padStart(2, "0");
 
     // Add future date
-    await register.selectFutureDate(year, month, day);
-    await expect(register.submitButton).toBeDisabled();
+    await registerPage.selectFutureDate(year, month, day);
+    await expect(registerPage.submitButton).toBeDisabled();
   });
 });

--- a/tests/registration/email.spec.ts
+++ b/tests/registration/email.spec.ts
@@ -1,51 +1,47 @@
-import { expect, test } from "@playwright/test";
-import { RegisterPage } from "../../src/pages/registrationPage";
+import { expect } from "@playwright/test";
+import { test } from '../../src/fixtures/fixture_register'
 import { generateUniqueEmail, InvalidEmail, TestData } from "../../src/testData/testData";
 
 test.describe("Email Suite", () => {
-  let register: RegisterPage;
-
-  test.beforeEach(async ({ page }) => {
-    register = new RegisterPage(page);
-    await register.goto();
-    await register.fillEmailInput("");
-    await register.fillFirstname(TestData.FIRSTNAME);
-    await register.fillLastname(TestData.LASTNAME);
-    await register.fillDateOfBirth(TestData.DATE_OF_BIRTH);
-    await register.fillPassword(TestData.PASSWORD);
-    await register.fillConfirmPassword(TestData.PASSWORD);
+  test.beforeEach(async ({ registerPage }) => {
+    await registerPage.goto();
+    await registerPage.fillEmailInput("");
+    await registerPage.fillFirstname(TestData.FIRSTNAME);
+    await registerPage.fillLastname(TestData.LASTNAME);
+    await registerPage.fillDateOfBirth(TestData.DATE_OF_BIRTH);
+    await registerPage.fillPassword(TestData.PASSWORD);
+    await registerPage.fillConfirmPassword(TestData.PASSWORD);
   });
 
 
-  test('[AQAPRACT-523] Register with empty "Email" field', async ({ page }) => {
-    await register.fillEmailInput("");
-    await expect(register.submitButton).toBeDisabled();
+  test('[AQAPRACT-523] Register with empty "Email" field', async ({ registerPage }) => {
+    await registerPage.fillEmailInput("");
+    await expect(registerPage.submitButton).toBeDisabled();
   });
 
 
   test("[AQAPRACT-524] Register with invalid format of email address", async ({
-    page,
+   registerPage
   }) => {
     for (const emailValueInvalid of Object.values(InvalidEmail)) {
-      await register.fillEmailInput(emailValueInvalid);
-      await register.invalidEmailError();
+      await registerPage.fillEmailInput(emailValueInvalid);
+      await registerPage.invalidEmailError();
     }
   });
 
 
-  test('[AQAPRAC-525] Register with already existed email', async({page}) => {
+  test('[AQAPRAC-525] Register with already existed email', async({registerPage}) => {
     const testEmailAddress: string = 'testexisting1@example.com';
-    await register.fillEmailInput(testEmailAddress);
-    await register.submitButton.click();
-    await expect(page).toHaveURL('https://qa-course-01.andersenlab.com/login')
-
+    await registerPage.fillEmailInput(testEmailAddress);
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage()).toHaveURL('https://qa-course-01.andersenlab.com/login')
     // refresh and again submit with same email
-    const registrationLink = page.locator('span:has-text("Registration")');
+    const registrationLink = registerPage.getPage().locator('span:has-text("Registration")');
     await registrationLink.click();
-    await register.fillEmailInput(generateUniqueEmail());
-    await register.fillEmailInput(testEmailAddress);
-    await register.submitButton.click();
-    await register.dublicateEmailError();
+    await registerPage.fillEmailInput(generateUniqueEmail());
+    await registerPage.fillEmailInput(testEmailAddress);
+    await registerPage.submitButton.click();
+    await registerPage.dublicateEmailError();
   })
 
 });

--- a/tests/registration/email.spec.ts
+++ b/tests/registration/email.spec.ts
@@ -13,7 +13,6 @@ test.describe("Email Suite", () => {
     await registerPage.fillConfirmPassword(TestData.PASSWORD);
   });
 
-
   test('[AQAPRACT-523] Register with empty "Email" field', async ({ registerPage }) => {
     await registerPage.fillEmailInput("");
     await expect(registerPage.submitButton).toBeDisabled();

--- a/tests/registration/firstname.spec.ts
+++ b/tests/registration/firstname.spec.ts
@@ -2,13 +2,8 @@ import { expect } from "@playwright/test";
 import {test} from '../../src/fixtures/fixture_register';
 import { generateUniqueEmail, TestData } from "../../src/testData/testData";
 
-// import { RegisterPage } from "../../src/pages/registrationPage";
- 
 test.describe("First name Suite", () => {
-  // let register: RegisterPage;
-
   test.beforeEach(async ({ registerPage }) => {
-    // register = new RegisterPage(page);
     await registerPage.goto();
     await registerPage.fillLastname(TestData.LASTNAME);
     await registerPage.fillDateOfBirth(TestData.DATE_OF_BIRTH);

--- a/tests/registration/firstname.spec.ts
+++ b/tests/registration/firstname.spec.ts
@@ -1,70 +1,67 @@
-import { expect, test } from "@playwright/test";
-import { RegisterPage } from "../../src/pages/registrationPage";
+import { expect } from "@playwright/test";
+import {test} from '../../src/fixtures/fixture_register';
 import { generateUniqueEmail, TestData } from "../../src/testData/testData";
 
+// import { RegisterPage } from "../../src/pages/registrationPage";
+ 
 test.describe("First name Suite", () => {
-  let register: RegisterPage;
+  // let register: RegisterPage;
 
-  test.beforeEach(async ({ page }) => {
-    register = new RegisterPage(page);
-    await register.goto();
-    await register.fillLastname(TestData.LASTNAME);
-    await register.fillDateOfBirth(TestData.DATE_OF_BIRTH);
-    await register.fillPassword(TestData.PASSWORD);
-    await register.fillConfirmPassword(TestData.PASSWORD);
-    await register.fillEmailInput(generateUniqueEmail());
+  test.beforeEach(async ({ registerPage }) => {
+    // register = new RegisterPage(page);
+    await registerPage.goto();
+    await registerPage.fillLastname(TestData.LASTNAME);
+    await registerPage.fillDateOfBirth(TestData.DATE_OF_BIRTH);
+    await registerPage.fillPassword(TestData.PASSWORD);
+    await registerPage.fillConfirmPassword(TestData.PASSWORD);
+    await registerPage.fillEmailInput(generateUniqueEmail());
   });
 
-  test("AQAPRACT-509 Register with max First name length (255 characters)", async ({
-    page,
+  test("AQAPRACT-509 Register with max First name length (255 characters)", async ({registerPage
   }) => {
     const maxLength = "A".repeat(255);
+ 
+    await registerPage.fillFirstname(maxLength);
+    await expect(registerPage.firstnameInput).toHaveValue(maxLength);
 
-    await register.fillFirstname(maxLength);
-    await expect(register.firstnameInput).toHaveValue(maxLength);
-
-    await register.submitButton.click();
-    await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage()).toHaveURL("https://qa-course-01.andersenlab.com/login");
   });
 
-  test("AQAPRACT-510 Register with min First name length (1 character)", async ({
-    page,
+  test("AQAPRACT-510 Register with min First name length (1 character)", async ({ registerPage
   }) => {
-    await register.fillFirstname("A");
-    await expect(register.firstnameInput).toHaveValue("A");
+    await registerPage.fillFirstname("A");
+    await expect(registerPage.firstnameInput).toHaveValue("A");
 
-    await register.submitButton.click();
-    await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage()).toHaveURL("https://qa-course-01.andersenlab.com/login");
   });
 
-  test("AQAPRACT-511 Register with max+1 First name length (256 characters)", async ({
-    page,
+  test("AQAPRACT-511 Register with max+1 First name length (256 characters)", async ({ registerPage
   }) => {
     const aboveMaxLength = "A".repeat(256);
 
-    await register.fillFirstname(aboveMaxLength);
-    await expect(register.firstnameInput).toHaveValue(aboveMaxLength);
+    await registerPage.fillFirstname(aboveMaxLength);
+    await expect(registerPage.firstnameInput).toHaveValue(aboveMaxLength);
 
-    await register.submitButton.click();
-    await expect(register.firstnameInput).toHaveClass(/border-rose-500/);
+    await registerPage.submitButton.click();
+    await expect(registerPage.firstnameInput).toHaveClass(/border-rose-500/);
     await expect(
-      page.locator("text=The value length shouldn't exceed 255 symbols")
+      registerPage.getPage().locator("text=The value length shouldn't exceed 255 symbols")
     ).toBeVisible();
   });
 
-  test("AQAPRACT-512 Register with empty First name field", async () => {
-    await register.fillFirstname("");
-    await expect(register.firstnameInput).toHaveValue("");
-    await expect(register.submitButton).toBeDisabled();
+  test("AQAPRACT-512 Register with empty First name field", async ({registerPage}) => {
+    await expect(registerPage.firstnameInput).toHaveValue("");
+    await expect(registerPage.submitButton).toBeDisabled();
   });
 
-  test("AQAPRACT-513 Register with spaces in First name field", async ({
-    page,
+  test("AQAPRACT-513 Register with spaces in First name field", async ({ registerPage
   }) => {
-    await register.fillFirstname("   ");
-    await expect(register.firstnameInput).toHaveValue("   ");
-    await register.submitButton.click();
-    await expect(page.locator("text=The field is required.")).toBeVisible();
-    await expect(register.firstnameInput).toHaveClass(/border-rose-500/);
+    await registerPage.fillFirstname("   ");
+    await expect(registerPage.firstnameInput).toHaveValue("   ");
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage().locator("text=The field is required.")).toBeVisible();
+    await expect(registerPage.firstnameInput).toHaveClass(/border-rose-500/);
   });
 });

--- a/tests/registration/lastname.spec.ts
+++ b/tests/registration/lastname.spec.ts
@@ -3,10 +3,7 @@ import {test} from '../../src/fixtures/fixture_register';
 import { generateUniqueEmail, TestData } from "../../src/testData/testData";
 
 test.describe("Last name Suite", () => {
-  // let register: RegisterPage;
-
   test.beforeEach(async ({ registerPage }) => {
-    // registerPage = new RegisterPage(page);
     await registerPage.goto();
     await registerPage.fillFirstname(TestData.FIRSTNAME);
     await registerPage.fillLastname(TestData.LASTNAME);

--- a/tests/registration/lastname.spec.ts
+++ b/tests/registration/lastname.spec.ts
@@ -1,70 +1,70 @@
-import { expect, test } from "@playwright/test";
-import { RegisterPage } from "../../src/pages/registrationPage";
+import { expect } from "@playwright/test";
+import {test} from '../../src/fixtures/fixture_register';
 import { generateUniqueEmail, TestData } from "../../src/testData/testData";
 
 test.describe("Last name Suite", () => {
-  let register: RegisterPage;
+  // let register: RegisterPage;
 
-  test.beforeEach(async ({ page }) => {
-    register = new RegisterPage(page);
-    await register.goto();
-    await register.fillFirstname(TestData.FIRSTNAME);
-    await register.fillLastname(TestData.LASTNAME);
-    await register.fillDateOfBirth(TestData.DATE_OF_BIRTH);
-    await register.fillPassword(TestData.PASSWORD);
-    await register.fillConfirmPassword(TestData.PASSWORD);
-    await register.fillEmailInput(generateUniqueEmail());
+  test.beforeEach(async ({ registerPage }) => {
+    // registerPage = new RegisterPage(page);
+    await registerPage.goto();
+    await registerPage.fillFirstname(TestData.FIRSTNAME);
+    await registerPage.fillLastname(TestData.LASTNAME);
+    await registerPage.fillDateOfBirth(TestData.DATE_OF_BIRTH);
+    await registerPage.fillPassword(TestData.PASSWORD);
+    await registerPage.fillConfirmPassword(TestData.PASSWORD);
+    await registerPage.fillEmailInput(generateUniqueEmail());
   });
 
   test("[AQAPRACT-514] Register with max Last name length (255 characters)", async ({
-    page,
+    registerPage,
   }) => {
     const maxLength = "A".repeat(255);
-    await register.fillLastname(maxLength);
-    await expect(register.lastnameInput).toHaveValue(maxLength);
-    await register.submitButton.click();
-    await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
+    await registerPage.fillLastname(maxLength);
+    await expect(registerPage.lastnameInput).toHaveValue(maxLength);
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage()).toHaveURL("https://qa-course-01.andersenlab.com/login");
   });
 
   test("[AQAPRACT-515] Register with min Last name length (1 character)", async ({
-    page,
+    registerPage
   }) => {
-    await register.fillLastname("A");
-    await expect(register.lastnameInput).toHaveValue("A");
+    await registerPage.fillLastname("A");
+    await expect(registerPage.lastnameInput).toHaveValue("A");
 
-    await register.submitButton.click();
-    await expect(page).toHaveURL("https://qa-course-01.andersenlab.com/login");
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage()).toHaveURL("https://qa-course-01.andersenlab.com/login");
   });
 
   test("[AQAPRACT-516] Register with max+1 Last name length (256 characters)", async ({
-    page,
+    registerPage
   }) => {
     const aboveMaxLength = "A".repeat(256);
 
-    await register.fillLastname(aboveMaxLength);
-    await expect(register.lastnameInput).toHaveValue(aboveMaxLength);
+    await registerPage.fillLastname(aboveMaxLength);
+    await expect(registerPage.lastnameInput).toHaveValue(aboveMaxLength);
 
-    await register.submitButton.click();
-    await expect(register.lastnameInput).toHaveClass(/border-rose-500/);
+    await registerPage.submitButton.click();
+    await expect(registerPage.lastnameInput).toHaveClass(/border-rose-500/);
     await expect(
-      page.locator("text=The value length shouldn't exceed 255 symbols")
+      registerPage.getPage().locator("text=The value length shouldn't exceed 255 symbols")
     ).toBeVisible();
   });
 
-  test("[AQAPRACT-517] Register with empty Last name field", async () => {
-    await register.fillLastname("");
-    await expect(register.lastnameInput).toHaveValue("");
+  test("[AQAPRACT-517] Register with empty Last name field", async ({registerPage}) => {
+    await registerPage.fillLastname("");
+    await expect(registerPage.lastnameInput).toHaveValue("");
 
-    await expect(register.submitButton).toBeDisabled();
+    await expect(registerPage.submitButton).toBeDisabled();
   });
 
   test("[AQAPRACT-518] Register with spaces in Last name field", async ({
-    page,
+    registerPage
   }) => {
-    await register.fillLastname("   ");
-    await expect(register.lastnameInput).toHaveValue("   ");
-    await register.submitButton.click();
-    await expect(page.locator("text=The field is required.")).toBeVisible();
-    await expect(register.lastnameInput).toHaveClass(/border-rose-500/);
+    await registerPage.fillLastname("   ");
+    await expect(registerPage.lastnameInput).toHaveValue("   ");
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage().locator("text=The field is required.")).toBeVisible();
+    await expect(registerPage.lastnameInput).toHaveClass(/border-rose-500/);
   });
 });

--- a/tests/registration/password.spec.ts
+++ b/tests/registration/password.spec.ts
@@ -1,109 +1,107 @@
-import { expect, test } from "@playwright/test";
-import { RegisterPage } from "../../src/pages/registrationPage";
+import { expect } from "@playwright/test";
 import { generateUniqueEmail, TestData } from "../../src/testData/testData";
+import { test } from '../../src/fixtures/fixture_register';
+
 
 test.describe("Password Suite", () => {
-  let register: RegisterPage;
-
-  test.beforeEach(async ({ page }) => {
-    register = new RegisterPage(page);
-    await register.goto();
-    await register.fillPassword("");
-    await register.fillConfirmPassword("");
-    await register.fillFirstname(TestData.FIRSTNAME);
-    await register.fillLastname(TestData.LASTNAME);
-    await register.fillDateOfBirth(TestData.DATE_OF_BIRTH);
-    await register.fillEmailInput(generateUniqueEmail());
+  test.beforeEach(async ({ registerPage }) => {
+    await registerPage.goto();
+    await registerPage.fillPassword("");
+    await registerPage.fillConfirmPassword("");
+    await registerPage.fillFirstname(TestData.FIRSTNAME);
+    await registerPage.fillLastname(TestData.LASTNAME);
+    await registerPage.fillDateOfBirth(TestData.DATE_OF_BIRTH);
+    await registerPage.fillEmailInput(generateUniqueEmail());
   });
 
   test("[AQAPRACT-526] Register with min Password length (8 characters)", async ({
-    page,
+    registerPage
   }) => {
     const passwordLenght8: string = "A".repeat(8);
-    await register.fillPassword(passwordLenght8);
-    await expect(register.passwordInput).toHaveValue(passwordLenght8);
-    await register.fillConfirmPassword(passwordLenght8);
-    await expect(register.passwordInput).toHaveValue(passwordLenght8);
-    await register.submitButton.click();
-    await expect(register.page).toHaveURL(
+    await registerPage.fillPassword(passwordLenght8);
+    await expect(registerPage.passwordInput).toHaveValue(passwordLenght8);
+    await registerPage.fillConfirmPassword(passwordLenght8);
+    await expect(registerPage.passwordInput).toHaveValue(passwordLenght8);
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage()).toHaveURL(
       "https://qa-course-01.andersenlab.com/login"
     );
   });
 
   test("[AQAPRACT-527] Register with max Password length (20 characters)", async ({
-    page,
+    registerPage
   }) => {
     const passwordLenght20: string = "A".repeat(20);
-    await register.fillPassword(passwordLenght20);
-    await expect(register.passwordInput).toHaveValue(passwordLenght20);
-    await register.fillConfirmPassword(passwordLenght20);
-    await expect(register.passwordInput).toHaveValue(passwordLenght20);
-    await register.submitButton.click();
-    await expect(register.page).toHaveURL(
+    await registerPage.fillPassword(passwordLenght20);
+    await expect(registerPage.passwordInput).toHaveValue(passwordLenght20);
+    await registerPage.fillConfirmPassword(passwordLenght20);
+    await expect(registerPage.passwordInput).toHaveValue(passwordLenght20);
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage()).toHaveURL(
       "https://qa-course-01.andersenlab.com/login"
     );
   });
 
   test("[AQAPRACT-528] Register with min-1 Password length (7 characters)", async ({
-    page,
+    registerPage
   }) => {
     const passwordLenght7: string = "A".repeat(7);
-    await register.fillPassword(passwordLenght7);
-    await expect(register.passwordInput).toHaveValue(passwordLenght7);
-    await register.invalidPasswordError();
-    await expect(register.passwordErrorMin).toBeVisible();
+    await registerPage.fillPassword(passwordLenght7);
+    await expect(registerPage.passwordInput).toHaveValue(passwordLenght7);
+    await registerPage.invalidPasswordError();
+    await expect(registerPage.passwordErrorMin).toBeVisible();
   });
 
   test("[AQAPRACT-529] Register with max+1 Password length (21 characters)", async ({
-    page,
+    registerPage
   }) => {
     const passwordLenghtMax: string = "A".repeat(21);
-    await register.fillPassword(passwordLenghtMax);
-    await expect(register.passwordInput).toHaveValue(passwordLenghtMax);
-    await register.invalidPasswordError();
-    await expect(register.passwordErrorMax).toBeVisible();
+    await registerPage.fillPassword(passwordLenghtMax);
+    await expect(registerPage.passwordInput).toHaveValue(passwordLenghtMax);
+    await registerPage.invalidPasswordError();
+    await expect(registerPage.passwordErrorMax).toBeVisible();
   });
 
   test("[AQAPRACT-530] Register with empty Password field", async ({
-    page,
+    registerPage
   }) => {
     const emptyPassword: string = "";
-    await register.fillPassword(emptyPassword);
-    await expect(register.passwordInput).toHaveValue("");
-    await expect(register.submitButton).toBeDisabled();
+    await registerPage.fillPassword(emptyPassword);
+    await expect(registerPage.passwordInput).toHaveValue("");
+    await expect(registerPage.submitButton).toBeDisabled();
   });
 
   // Confirm Password Suite
 
   test("[AQAPRACT-531] Register with equal data Password and Confirm password fields", async ({
-    page,
+    registerPage
   }) => {
     const passwordData: string = "TestConf11";
-    await register.fillPassword(passwordData);
-    await register.fillConfirmPassword(passwordData);
-    await register.submitButton.click();
-    await expect(register.page).toHaveURL("https://qa-course-01.andersenlab.com/login");
+    await registerPage.fillPassword(passwordData);
+    await registerPage.fillConfirmPassword(passwordData);
+    await registerPage.submitButton.click();
+    await expect(registerPage.getPage()).toHaveURL("https://qa-course-01.andersenlab.com/login");
   });
 
 
   test("[AQAPRACT-532] Register with different data in Password and Confirm password fields", async ({
-    page,
+    registerPage
   }) => {
-    await register.fillPassword("TestConf11");
-    await register.fillConfirmPassword("TestConf12");
-    await expect(register.submitButton).toBeDisabled();
-    await expect(register.confirmPasswordError).toBeVisible();
+    await registerPage.fillPassword("TestConf11");
+    await registerPage.fillConfirmPassword("TestConf12");
+    await expect(registerPage.submitButton).toBeDisabled();
+    await expect(registerPage.confirmPasswordError).toBeVisible();
   });
 
   
   test("[AQAPRACT-533] Register with empty Confirm password field", async ({
-    page,
+    registerPage
   }) => {
     const passwordData: string = "TestConf11";
-    await register.fillPassword(passwordData);
+    await registerPage.fillPassword(passwordData);
     const emptyConfirmPass: string = "";
-    await register.fillConfirmPassword(emptyConfirmPass);
-    await expect(register.emptyConfirmPasswordError).toBeVisible();
-    await expect(register.emptyConfirmPasswordError).toHaveText("Required");
+    await registerPage.fillConfirmPassword(emptyConfirmPass);
+    await expect(registerPage.emptyConfirmPasswordError).toBeVisible();
+    await expect(registerPage.emptyConfirmPasswordError).toHaveText("Required");
   });
 });

--- a/tests/signIn/signIn.spec.ts
+++ b/tests/signIn/signIn.spec.ts
@@ -1,71 +1,70 @@
-import { expect, test } from "@playwright/test";
-import { SignInPage } from "../../src/pages/signInPage";
+import { expect } from "@playwright/test";
+import { test } from '../../src/fixtures/fixture_signIn';
+// import { SignInPage } from "../../src/pages/signInPage";
 import { TestDataSignin } from "../../src/testData/testData";
 
-let signIn: SignInPage;
 
 //! Email input
 test.describe("Sign In Suite: Email Address", () => {
-  test.beforeEach(async ({ page }) => {
-    signIn = new SignInPage(page);
-    await signIn.goto();
+  
+  test.beforeEach(async ({ signInPage }) => {
+    await signInPage.goto();
   });
 
   test('[AQAPRACT-539] Validation of empty "Email" field on "Sign in" page', async ({
-    page,
+    signInPage
   }) => {
-    await signIn.fillEmailAddress("");
-    await signIn.fillPasswordInput(TestDataSignin.PASSWORD);
-    await expect(signIn.emailAddressInput).toHaveValue("");
-    await signIn.verifyErrorRequiredEmail();
+    await signInPage.fillEmailAddress("");
+    await signInPage.fillPasswordInput(TestDataSignin.PASSWORD);
+    await expect(signInPage.emailAddressInput).toHaveValue("");
+    await signInPage.verifyErrorRequiredEmail();
   });
 });
 
 //! Password input
 test.describe("Sign In Suite: Password", () => {
-  test.beforeEach(async ({ page }) => {
-    signIn = new SignInPage(page);
-    await signIn.goto();
+  test.beforeEach(async ({ signInPage }) => {
+    await signInPage.goto();
   });
 
   test("[AQAPRACT-540] Validation of empty Password field on sign in page", async ({
-    page,
+    signInPage
   }) => {
-    await signIn.fillEmailAddress(TestDataSignin.EMAIL);
-    await expect(signIn.emailAddressInput).toHaveValue(TestDataSignin.EMAIL);
-    await signIn.fillPasswordInput("");
-    await signIn.emailAddressInput.click();
-    await expect(signIn.passwordInput).toHaveValue("");
-    await signIn.verifyErrorRequiredPassword();
+    await signInPage.fillEmailAddress(TestDataSignin.EMAIL);
+    await expect(signInPage.emailAddressInput).toHaveValue(TestDataSignin.EMAIL);
+    await signInPage.fillPasswordInput("");
+    await signInPage.emailAddressInput.click();
+    await expect(signInPage.passwordInput).toHaveValue("");
+    await signInPage.verifyErrorRequiredPassword();
   });
 
-  test('[AQAPRACT-541] Validation of "Password" on min length (8 characters)', async () => {
-    await signIn.fillPasswordInput(TestDataSignin.PASSWORD_MIN);
-    await expect(signIn.passwordErrorMinMsg).not.toBeVisible();
+  test('[AQAPRACT-541] Validation of "Password" on min length (8 characters)', async ({signInPage}) => {
+    await signInPage.fillPasswordInput(TestDataSignin.PASSWORD_MIN);
+    await expect(signInPage.passwordErrorMinMsg).not.toBeVisible();
     // check masked
-    await expect(signIn.passwordInput).toHaveAttribute("type", "password");
+    await expect(signInPage.passwordInput).toHaveAttribute("type", "password");
   });
 
-  test('[AQAPRACT-542] Validation of "Password" on max length (20 characters)', async () => {
-    await signIn.fillEmailAddress(TestDataSignin.EMAIL);
-    await signIn.fillPasswordInput(TestDataSignin.PASSWORD_MAX);
-    await expect(signIn.passwordErrorMinMsg).not.toBeVisible();
-    await expect(signIn.submitButtonSignIn).toBeVisible();
+  test('[AQAPRACT-542] Validation of "Password" on max length (20 characters)', async ({signInPage}) => {
+    await signInPage.fillEmailAddress(TestDataSignin.EMAIL);
+    await signInPage.fillPasswordInput(TestDataSignin.PASSWORD_MAX);
+    await expect(signInPage.passwordErrorMinMsg).not.toBeVisible();
+    await expect(signInPage.submitButtonSignIn).toBeVisible();
   });
 
-  test('[AQAPRACT-543] Validation of "Password" on 7 characters', async () => {
-    await signIn.fillEmailAddress(TestDataSignin.EMAIL);
-    await signIn.fillPasswordInput(TestDataSignin.PASSWORD_UNDER_MIN);
-    await signIn.emailAddressInput.click();
-    await expect(signIn.passwordInput).toHaveClass(/border-rose-500/);
-    await expect(signIn.passwordErrorMinMsg).toBeVisible();
+  test('[AQAPRACT-543] Validation of "Password" on 7 characters', async ({signInPage}) => {
+    await signInPage.fillEmailAddress(TestDataSignin.EMAIL);
+    await signInPage.fillPasswordInput(TestDataSignin.PASSWORD_UNDER_MIN);
+    await signInPage.emailAddressInput.click();
+    await expect(signInPage.passwordInput).toHaveClass(/border-rose-500/);
+    await expect(signInPage.passwordErrorMinMsg).toBeVisible();
   });
 
-  test('[AQAPRACT-544] Validation of "Password" on 21 chacacters', async () => {
-    await signIn.fillEmailAddress(TestDataSignin.EMAIL);
-    await signIn.fillPasswordInput(TestDataSignin.PASSWORD_OVER_MAX);
-    await signIn.emailAddressInput.click();
-    await expect(signIn.passwordInput).toHaveClass(/border-rose-500/);
-    await expect(signIn.passwordErrorMaxMsg).toBeVisible();
+  test('[AQAPRACT-544] Validation of "Password" on 21 chacacters', async ({signInPage}) => {
+    await signInPage.fillEmailAddress(TestDataSignin.EMAIL);
+    await signInPage.fillPasswordInput(TestDataSignin.PASSWORD_OVER_MAX);
+    await signInPage.emailAddressInput.click();
+    await expect(signInPage.passwordInput).toHaveClass(/border-rose-500/);
+    await expect(signInPage.passwordErrorMaxMsg).toBeVisible();
   });
 });

--- a/tests/signIn/signIn.spec.ts
+++ b/tests/signIn/signIn.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from "@playwright/test";
 import { test } from '../../src/fixtures/fixture_signIn';
-// import { SignInPage } from "../../src/pages/signInPage";
 import { TestDataSignin } from "../../src/testData/testData";
 
 

--- a/tests/userProfile/userProfile.spec.ts
+++ b/tests/userProfile/userProfile.spec.ts
@@ -1,52 +1,44 @@
-import { test, expect } from "@playwright/test";
-import { UserProfilePage } from "../../src/pages/userProfilePage";
-import { SignInPage } from "../../src/pages/signInPage";
+import { expect } from "@playwright/test";
+import { test } from '../../src/fixtures/fixture_signIn';
 import { PageUrls, TestDataSignin } from "../../src/testData/testData";
-
-let userProfilePage: UserProfilePage;
-let signIn: SignInPage;
 
 //! User Profile Suite
 test.describe("User Profile Suite", async () => {
-  test.beforeEach(async ({ page }) => {
-    signIn = new SignInPage(page);
-    await signIn.goto();
-    await signIn.fillEmailAddress(TestDataSignin.EMAIL);
-    await signIn.fillPasswordInput(TestDataSignin.PASSWORD);
-    await signIn.submit();
-    userProfilePage = new UserProfilePage(page);
+  test.beforeEach(async ({ signInPage }) => {
+    await signInPage.goto();
+    await signInPage.fillEmailAddress(TestDataSignin.EMAIL);
+    await signInPage.fillPasswordInput(TestDataSignin.PASSWORD);
+    await signInPage.submit();
   });
 
-  test('[AQAPRACT-545] Validation of "User profile" page layout', async () => {
+  test('[AQAPRACT-545] Validation of "User profile" page layout', async ({userProfilePage}) => {
     await userProfilePage.verifyProfileLayout();
   });
 
-  test("[AQAPRACT-546] Successful Sign Out", async () => {
+  test("[AQAPRACT-546] Successful Sign Out", async ({userProfilePage}) => {
     await userProfilePage.signOutSuccessfully();
   });
 
-  test('[AQAPRACT-547] "AQA Practice" dropdown options validation', async () => {
+  test('[AQAPRACT-547] "AQA Practice" dropdown options validation', async ({userProfilePage}) => {
     await userProfilePage.verifyDropdownOptions();
   });
 });
 
 //! Edit Profile Suite
 test.describe("Edit Profile Suite", async () => {
-  test.beforeEach(async ({ page }) => {
-    signIn = new SignInPage(page);
-    await signIn.goto();
-    await signIn.fillEmailAddress(TestDataSignin.EMAIL);
-    await signIn.fillPasswordInput(TestDataSignin.PASSWORD);
-    await signIn.submit();
-    userProfilePage = new UserProfilePage(page);
+  test.beforeEach(async ({ signInPage }) => {
+    await signInPage.goto();
+    await signInPage.fillEmailAddress(TestDataSignin.EMAIL);
+    await signInPage.fillPasswordInput(TestDataSignin.PASSWORD);
+    await signInPage.submit();
   });
 
-  test('[AQAPRACT-548] "Edit personal information" flyout available', async () => {
+  test('[AQAPRACT-548] "Edit personal information" flyout available', async ({userProfilePage}) => {
     await userProfilePage.editButton.click();
     await userProfilePage.verifyEditPersonalInfoModal();
   });
 
-  test("[AQAPRACT-549] Edit 'First name' on User profile flyout", async () => {
+  test("[AQAPRACT-549] Edit 'First name' on User profile flyout", async ({userProfilePage}) => {
     await userProfilePage.editButton.click();
     const newName: string = "NewAQA";
     await userProfilePage.updateFirstname(newName);
@@ -54,7 +46,7 @@ test.describe("Edit Profile Suite", async () => {
     await expect(userProfilePage.userName).toContainText(newName);
   });
 
-  test('[AQAPRACT-550] Edit "Last name" on User profile flyout', async () => {
+  test('[AQAPRACT-550] Edit "Last name" on User profile flyout', async ({userProfilePage}) => {
     await userProfilePage.editButton.click();
     const newLastName = "Test";
     await userProfilePage.updateLastname(newLastName);
@@ -62,7 +54,7 @@ test.describe("Edit Profile Suite", async () => {
     await expect(userProfilePage.userName).toContainText(newLastName);
   });
 
-  test('[AQAPRACT-551] Edit "Email" on User profile flyout', async () => {
+  test('[AQAPRACT-551] Edit "Email" on User profile flyout', async ({userProfilePage}) => {
     await userProfilePage.editButton.click();
     const newEmail: string = "ziqa1@gmail.com";
     await userProfilePage.emailInput.fill(newEmail);
@@ -72,7 +64,7 @@ test.describe("Edit Profile Suite", async () => {
     await userProfilePage.clickSave();
   });
 
-  test('[AQAPRACT-552] Edit "Date of Birth" on User profile flyout', async () => {
+  test('[AQAPRACT-552] Edit "Date of Birth" on User profile flyout', async ({userProfilePage}) => {
     await userProfilePage.editButton.click();
     const newDate = "01/01/2000";
     await userProfilePage.updateDateOfBirth(newDate);
@@ -80,21 +72,21 @@ test.describe("Edit Profile Suite", async () => {
     await expect(userProfilePage.dateOfBirth).toHaveText(newDate);
   });
 
-  test("[AQAPRACT-553] Cancel editing the data on the flyout (after the data is edited)", async () => {
+  test("[AQAPRACT-553] Cancel editing the data on the flyout (after the data is edited)", async ({userProfilePage}) => {
     await userProfilePage.editButton.click();
     await userProfilePage.updateFirstname("TemporaryName");
     await userProfilePage.clickCancel();
     await expect(userProfilePage.userName).not.toContainText("TemporaryName");
   });
 
-  test("[AQAPRACT-554] Cancel editing the data on the flyout (without editing)", async () => {
+  test("[AQAPRACT-554] Cancel editing the data on the flyout (without editing)", async ({userProfilePage}) => {
     await userProfilePage.editButton.click();
     await userProfilePage.clickCancel();
     await expect(userProfilePage.editPersonalInfoTitle).toHaveCount(0);
     await expect(userProfilePage.getPage()).toHaveURL(PageUrls.USER_PROFILE)
   });
 
-  test('[AQAPRACT-555] Close "Edit personal information" flyout by "X" button', async () => {
+  test('[AQAPRACT-555] Close "Edit personal information" flyout by "X" button', async ({userProfilePage}) => {
     await userProfilePage.editButton.click();
     const originalFirstName = await userProfilePage.firstNameInput.inputValue();
     await userProfilePage.updateFirstname("TemporaryName");


### PR DESCRIPTION
This PR refactors the following pages by replacing the existing code with fixtures:
1. Registration
2. Sign In
3. User Profile

The primary change involves using fixtures to handle repetitive logic, making the code more maintainable and readable. Specifically:
For the Sign In and User Profile pages, I've added a shared fixture since the User Profile page relies on Sign In functionality.
The Registration page also received fixture-based improvements for better test management.