### PR TITLE
Setup GitHub Actions for Playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [ ziyaret/CIsetup ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
This PR is in addition to the GitHub Actions workflow (.github/workflows/playwright.yml). 
Whenever `ziyarat/CIsetup` branch push or `main` pull request is opened to ensure automatic processing of Playwright tests. 

Changes:
- `.github/workflows/playwright.yml` was added usefully
- Workflow performs the following steps for Playwright:
  - Checking out the repo code
  - Installing Node.js
  - Installing NPM dependencies
  - Installing Playwright browsers
  - Release of tests to work
  - Adding to the test report as an artifact