### PR TITLE
Added Playwright automated tests for the "Select " Suite

### DIFF
--- a/src/fixtures/fixture_signIn.ts
+++ b/src/fixtures/fixture_signIn.ts
@@ -1,10 +1,12 @@
 import { test as base, type Page } from '@playwright/test';
 import { SignInPage } from '../pages/signInPage';
 import { UserProfilePage } from '../pages/userProfilePage';
+import { AqaPractice } from '../pages/aqaPractice';
 type MyFixtures = {
     page: Page;
     signInPage: SignInPage;
     userProfilePage: UserProfilePage;
+    aqaPractice: AqaPractice;
 };
 export const test = base.extend<MyFixtures>({
     signInPage: async ({ page }, use) => {
@@ -14,5 +16,9 @@ export const test = base.extend<MyFixtures>({
     userProfilePage: async ({ page }, use) => {
         const userProfilePage = new UserProfilePage(page);
         use(userProfilePage);
+    },
+    aqaPractice: async ({ page }, use) => {
+        const aqaPractice = new AqaPractice(page);
+        use(aqaPractice);
     },
 });

--- a/src/pages/aqaPractice.ts
+++ b/src/pages/aqaPractice.ts
@@ -16,9 +16,8 @@ export class AqaPractice extends BasePage {
     readonly selectType: Locator;
     readonly selectCoursesSection: Locator;
     readonly searchButton: Locator;
-    // Calendars and items for select date
-    readonly startDate: Locator;
-    readonly endDate: Locator;
+    readonly startDateInput: Locator;
+    readonly endDateInput: Locator;
     // Search result
     readonly searchResultsTitle: Locator;
     readonly courseCards: Locator;
@@ -26,7 +25,7 @@ export class AqaPractice extends BasePage {
     readonly courseName: Locator;
     readonly viewButton: Locator;
     // Select Course from list
-    readonly multipleSelectionBtn: Locator;
+    readonly selectionCourses: Locator;
     // No result message
     readonly noResultMessage: Locator;
 
@@ -45,10 +44,10 @@ export class AqaPractice extends BasePage {
         this.selectCountry = page.locator('select[title="Select country"]');
         this.selectLanguage = page.locator('#SelectLanguage');
         this.selectType = page.locator('select[title="Select type"]');
-        this.startDate = page.locator('input[title="Start date"]');
-        this.endDate = page.locator('input[title="End date"]');
+        this.startDateInput = page.locator('input[title="Start date"]');
+        this.endDateInput = page.locator('input[title="End date"]');
         this.selectCoursesSection = page.locator('h2', { hasText: 'Select courses' });
-        this.multipleSelectionBtn = page.locator('#MultipleSelect');
+        this.selectionCourses = page.locator('#MultipleSelect');
         this.searchButton = page.locator('button[name="SelectPageSearchButton"]');
         // Search results
         this.searchResultsTitle = page.locator('h1', { hasText: 'Search results' });
@@ -80,11 +79,11 @@ export class AqaPractice extends BasePage {
         await this.searchButton.click();
     }
     async selectSingleCourse(course: string): Promise<void> {
-        await this.multipleSelectionBtn.selectOption({ label: course });
+        await this.selectionCourses.selectOption({ label: course });
     }
     async selectMultipleCourses(courses: string[]): Promise<void> {
         for (const course of courses) {
-            await this.multipleSelectionBtn.selectOption({ label: course });
+            await this.selectionCourses.selectOption({ label: course });
         }
     }
 }

--- a/src/pages/aqaPractice.ts
+++ b/src/pages/aqaPractice.ts
@@ -1,0 +1,90 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { PageUrls } from '../testData/testData';
+import { BasePage } from './basePage';
+
+export class AqaPractice extends BasePage {
+    readonly aqaPracticeDropdown: Locator;
+    readonly selectItem: Locator;
+    readonly dragAndDropItem: Locator;
+    readonly actionAlertItem: Locator;
+    readonly backToProfileBtn: Locator;
+    // Select items
+    readonly chooseCourseTitle: Locator;
+    readonly defineStudyPreferencesSection: Locator;
+    readonly selectCountry: Locator;
+    readonly selectLanguage: Locator;
+    readonly selectType: Locator;
+    readonly selectCoursesSection: Locator;
+    readonly searchButton: Locator;
+    // Calendars and items for select date
+    readonly startDate: Locator;
+    readonly endDate: Locator;
+    // Search result
+    readonly searchResultsTitle: Locator;
+    readonly courseCards: Locator;
+    readonly courseCategory: Locator;
+    readonly courseName: Locator;
+    readonly viewButton: Locator;
+    // Select Course from list
+    readonly multipleSelectionBtn: Locator;
+    // No result message
+    readonly noResultMessage: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.aqaPracticeDropdown = page.locator('div.flex.cursor-pointer:has-text("AQA Practice")');
+        this.selectItem = page.locator('text=Select');
+        this.dragAndDropItem = page.locator('text=Drag & Drop');
+        this.actionAlertItem = page.locator('text=Actions, Alerts & Iframes');
+        this.backToProfileBtn = page.locator('a[data-test-id="NavLinkToHome"]');
+        // Select items
+        this.chooseCourseTitle = page.locator('h1', { hasText: 'Choose your course' });
+        this.defineStudyPreferencesSection = page.locator('h2', {
+            hasText: 'Define your study preferences',
+        });
+        this.selectCountry = page.locator('select[title="Select country"]');
+        this.selectLanguage = page.locator('#SelectLanguage');
+        this.selectType = page.locator('select[title="Select type"]');
+        this.startDate = page.locator('input[title="Start date"]');
+        this.endDate = page.locator('input[title="End date"]');
+        this.selectCoursesSection = page.locator('h2', { hasText: 'Select courses' });
+        this.multipleSelectionBtn = page.locator('#MultipleSelect');
+        this.searchButton = page.locator('button[name="SelectPageSearchButton"]');
+        // Search results
+        this.searchResultsTitle = page.locator('h1', { hasText: 'Search results' });
+        this.courseCards = page.locator('.course-card');
+        this.courseCategory = page.locator('h2.mt-5.text-[24px]');
+        this.courseName = page.locator('.p-10.bg-white.flex.cursor-pointer >> div.flex-1');
+        this.viewButton = page.locator('.p-10.bg-white.flex.cursor-pointer span:text("View")');
+        // No result message
+        this.noResultMessage = page.locator(
+            'text=Unfortunately, we did not find any courses matching your chosen criteria.'
+        );
+    }
+    //! Methods
+    async goto(): Promise<void> {
+        await super.goto(PageUrls.SELECT_COURSES);
+    }
+    async selectCountryFill(country: string): Promise<void> {
+        await this.selectCountry.selectOption({ label: country });
+        await expect(this.searchButton).toBeEnabled();
+    }
+    async selectLanguageFill(language: string): Promise<void> {
+        await this.selectLanguage.selectOption({ label: language });
+        await expect(this.searchButton).toBeEnabled();
+    }
+    async selectTypeFill(type: string): Promise<void> {
+        await this.selectType.selectOption({ label: type });
+    }
+    async clickSearchButton(): Promise<void> {
+        await this.searchButton.click();
+    }
+    async selectSingleCourse(course: string): Promise<void> {
+        await this.multipleSelectionBtn.selectOption({ label: course });
+    }
+    async selectMultipleCourses(courses: string[]): Promise<void> {
+        for (const course of courses) {
+            await this.multipleSelectionBtn.selectOption({ label: course });
+        }
+    }
+}

--- a/src/testData/testData.ts
+++ b/src/testData/testData.ts
@@ -28,6 +28,9 @@ export enum PageUrls {
     REGISTER = 'https://qa-course-01.andersenlab.com/registration',
     SIGNIN = 'https://qa-course-01.andersenlab.com/login',
     USER_PROFILE = 'https://qa-course-01.andersenlab.com/',
+    SELECT_COURSES = 'https://qa-course-01.andersenlab.com/select',
+    DRAG_AND_DROP = 'https://qa-course-01.andersenlab.com/dragndrop',
+    ACTIONS_AND_ALERTS = 'https://qa-course-01.andersenlab.com/actions'
 }
 export const TestFiles = {
     PHOTO: path.resolve('src/testData/files/testImage.png'),

--- a/tests/userProfile/AQA Prac/selectPrac.spec.ts
+++ b/tests/userProfile/AQA Prac/selectPrac.spec.ts
@@ -28,8 +28,8 @@ test.describe('AQA Practice - Select Suite', () => {
         await expect(aqaPractice.selectCountry).toBeVisible();
         await expect(aqaPractice.selectLanguage).toBeVisible();
         await expect(aqaPractice.selectType).toBeVisible();
-        await expect(aqaPractice.startDate).toBeVisible();
-        await expect(aqaPractice.endDate).toBeVisible();
+        await expect(aqaPractice.startDateInput).toBeVisible();
+        await expect(aqaPractice.endDateInput).toBeVisible();
         await expect(aqaPractice.selectCoursesSection).toBeVisible();
         await expect(aqaPractice.searchButton).toHaveClass(/bg-\[#EFEFF0\]/);
     });

--- a/tests/userProfile/AQA Prac/selectPrac.spec.ts
+++ b/tests/userProfile/AQA Prac/selectPrac.spec.ts
@@ -1,0 +1,99 @@
+import { expect } from '@playwright/test';
+import { test } from '../../../src/fixtures/fixture_signIn';
+import { PageUrls, TestDataSignin } from '../../../src/testData/testData';
+
+test.describe('AQA Practice - Select Suite', () => {
+    test.beforeEach(async ({ userProfilePage, signInPage, aqaPractice }) => {
+        await signInPage.goto();
+        await signInPage.fillEmailAddress(TestDataSignin.EMAIL);
+        await signInPage.fillPasswordInput(TestDataSignin.PASSWORD);
+        await signInPage.submit();
+        await expect(userProfilePage.getPage()).toHaveURL(PageUrls.USER_PROFILE);
+        await aqaPractice.aqaPracticeDropdown.hover();
+        await aqaPractice.selectItem.click();
+        await expect(aqaPractice.getPage()).toHaveURL(PageUrls.SELECT_COURSES);
+    });
+    test('[AQAPRACT-571] Validation element in Select course page', async ({ aqaPractice }) => {
+        await aqaPractice.backToProfileBtn.click();
+        await expect(aqaPractice.getPage()).toHaveURL(PageUrls.USER_PROFILE);
+        await aqaPractice.aqaPracticeDropdown.hover();
+        await expect(aqaPractice.selectItem).toBeVisible();
+        await expect(aqaPractice.dragAndDropItem).toBeVisible();
+        await expect(aqaPractice.actionAlertItem).toBeVisible();
+        await aqaPractice.selectItem.click();
+        // Verify elements
+        await expect(aqaPractice.backToProfileBtn).toBeVisible();
+        await expect(aqaPractice.chooseCourseTitle).toBeVisible();
+        await expect(aqaPractice.defineStudyPreferencesSection).toBeVisible();
+        await expect(aqaPractice.selectCountry).toBeVisible();
+        await expect(aqaPractice.selectLanguage).toBeVisible();
+        await expect(aqaPractice.selectType).toBeVisible();
+        await expect(aqaPractice.startDate).toBeVisible();
+        await expect(aqaPractice.endDate).toBeVisible();
+        await expect(aqaPractice.selectCoursesSection).toBeVisible();
+        await expect(aqaPractice.searchButton).toHaveClass(/bg-\[#EFEFF0\]/);
+    });
+    test('[AQAPRACT-572] Search for existing course', async ({ aqaPractice }) => {
+        await aqaPractice.selectTypeFill('Testing');
+        await expect(aqaPractice.searchButton).toBeEnabled();
+        await aqaPractice.clickSearchButton();
+        await expect(aqaPractice.getPage()).toHaveURL(/search_results/);
+        await expect(aqaPractice.searchResultsTitle).toBeVisible();
+        const courseCards = await aqaPractice.courseCards.all();
+        for (const courseCard of courseCards) {
+            await expect(courseCard.locator('.course-title')).toBeVisible();
+            await expect(courseCard.locator('.course-description')).toBeVisible();
+            await expect(courseCard.locator('.view-button')).toBeVisible();
+        }
+    });
+    test('[AQAPRACT-573] Search for a non-existent course', async ({ aqaPractice }) => {
+        await aqaPractice.selectCountryFill('Italy');
+        await expect(aqaPractice.searchButton).toBeEnabled();
+        await aqaPractice.selectLanguageFill('Dutch');
+        await expect(aqaPractice.searchButton).toBeEnabled();
+        await aqaPractice.clickSearchButton();
+        await expect(aqaPractice.noResultMessage).toBeVisible();
+    });
+    test('[AQAPRACT-574] Select country from drop-down list', async ({ aqaPractice }) => {
+        await aqaPractice.selectCountry.click();
+        await aqaPractice.selectCountryFill('Italy');
+        await expect(aqaPractice.selectCountry).toHaveValue('Italy');
+        await expect(aqaPractice.searchButton).toBeEnabled();
+    });
+    test('[AQAPRACT-575] Select a language from thelanguage drop-down list', async ({
+        aqaPractice,
+    }) => {
+        await aqaPractice.selectLanguage.click();
+        await aqaPractice.selectLanguageFill('Dutch');
+        await expect(aqaPractice.selectLanguage).toHaveValue('Dutch');
+        await expect(aqaPractice.searchButton).toBeEnabled();
+    });
+    test('[AQAPRACT-576] Select a type from the type drop-down list', async ({ aqaPractice }) => {
+        await aqaPractice.selectType.click();
+        await aqaPractice.selectTypeFill('Testing');
+        await expect(aqaPractice.selectType).toHaveValue('Testing');
+        await expect(aqaPractice.searchButton).toBeEnabled();
+    });
+    test('[AQAPRACT-581]  Select a course from the Select courses list', async ({
+        aqaPractice,
+    }) => {
+        await aqaPractice.selectSingleCourse('Frontend Development');
+        await aqaPractice.selectCountryFill('Italy');
+        await expect(aqaPractice.searchButton).toBeEnabled();
+        await aqaPractice.clickSearchButton();
+        await expect(aqaPractice.getPage()).toHaveURL(/search_results/);
+        await expect(aqaPractice.searchResultsTitle).toBeVisible();
+    });
+
+    test('[AQAPRACT-582]  Multiselection for course from the Select courses list', async ({
+        aqaPractice,
+    }) => {
+        const courses = ['Frontend Development', 'Backend Development'];
+        await aqaPractice.selectCountryFill('Italy');
+        await aqaPractice.selectMultipleCourses(courses);
+        await expect(aqaPractice.searchButton).toBeEnabled();
+        await aqaPractice.clickSearchButton();
+        await expect(aqaPractice.getPage()).toHaveURL(/search_results/);
+        await expect(aqaPractice.searchResultsTitle).toBeVisible();
+    });
+});


### PR DESCRIPTION
Changes:
- Extended AQA Practice object with new helper methods
- Improved test readability and reduced duplication by reusing page object methods.
- Assertions verify both UI visibility and state ('toHaveValue', 'toBeEnabled', 'toHaveURL').

Validation:
- All new tests pass locally with expected behavior.
- Confirmed that selecting single and multiple courses navigates correctly to '/search_results'.