### PR TITLE
AQA Practice: Drag and Drop Suite

### DIFF
--- a/src/pages/aqaPractice.ts
+++ b/src/pages/aqaPractice.ts
@@ -27,6 +27,33 @@ export class AqaPractice extends BasePage {
     readonly selectionCourses: Locator;
     // No result message
     readonly noResultMessage: Locator;
+    // Drag and Drop section
+    readonly sortResponsibilitiesTitle: Locator;
+    readonly sortResponsibleSubtitle: Locator;
+    readonly chips: Locator;
+    readonly chipWriteTestCases: Locator;
+    readonly chipTestingRequirements: Locator;
+    readonly chipAutomationScripts: Locator;
+    readonly chipFrameworkSetup: Locator;
+    readonly manualWorkTitle: Locator;
+    readonly manualCol1: Locator;
+    readonly manualCol2: Locator;
+    readonly automationWorkTitle: Locator;
+    readonly autoCol1: Locator;
+    readonly autoCol2: Locator;
+    readonly finishDragButton: Locator;
+    readonly congratulationPopup: Locator;
+    // Actions and Alerts section
+    readonly actionAlertPageTitle: Locator;
+    readonly actionAlertPageSubtitle: Locator;
+    readonly confirmButton: Locator;
+    readonly getDiscountButton: Locator;
+    readonly cancelCourseButton: Locator;
+    readonly actionResult: Locator;
+    readonly finishActionButton: Locator;
+    readonly confirmInfoIcon: Locator;
+    readonly tooltip: Locator;
+
     constructor(page: Page) {
         super(page);
         this.aqaPracticeDropdown = page.locator('div.flex.cursor-pointer:has-text("AQA Practice")');
@@ -57,6 +84,34 @@ export class AqaPractice extends BasePage {
         this.noResultMessage = page.locator(
             'text=Unfortunately, we did not find any courses matching your chosen criteria.'
         );
+        // Drag and Drop
+        this.sortResponsibilitiesTitle = page.locator('h1', { hasText: 'Sort your responsibilities' });
+        this.sortResponsibleSubtitle = page.locator('h2', { hasText: 'Place the blocks into the cells below' });
+        this.chips = page.locator('span[title="Draggable element"]');
+        this.chipWriteTestCases = page.locator('#manual1');
+        this.chipTestingRequirements = page.locator('#manual2');
+        this.chipAutomationScripts = page.locator('#auto1');
+        this.chipFrameworkSetup = page.locator('#auto2');
+        this.manualWorkTitle = page.locator('h3', { hasText: 'Manual Work' });
+        this.automationWorkTitle = page.locator('h3', { hasText: 'Automation Work' });
+        this.manualCol1 = page.locator('#target-manual1');
+        this.manualCol2 = page.locator('#target-manual2');
+        this.autoCol1 = page.locator('#target-auto1');
+        this.autoCol2 = page.locator('#target-auto2');
+        // Finish button
+        this.finishDragButton = page.locator('#DragNDropPageFinishButton');
+        // Success message
+        this.congratulationPopup = page.locator("text=Congratulations! Let's test for the best!");
+        // Actions and Alerts
+        this.actionAlertPageTitle = page.getByRole('heading', { name: 'Your application has been accepted!' });
+        this.actionAlertPageSubtitle = page.getByText('Click one of the buttons to complete your registration on Default course');
+        this.confirmButton = page.locator('#AlertButton');
+        this.getDiscountButton = page.getByRole('button', { name: 'Get Discount' });
+        this.cancelCourseButton = page.getByTestId('PromptButton');
+        this.actionResult = page.locator('div').filter({ hasText: /^Results:/ });
+        this.finishActionButton = page.getByRole('button', { name: 'Finish' });
+        this.confirmInfoIcon = page.locator('#AlertButton + .info-icon'); 
+        this.tooltip = page.locator('.tooltip');
     }
     //! Methods
     async goto(): Promise<void> {
@@ -83,5 +138,8 @@ export class AqaPractice extends BasePage {
         for (const course of courses) {
             await this.selectionCourses.selectOption({ label: course });
         }
+    }
+    async dragAndDrop(source: Locator, target: Locator): Promise<void> {
+        await source.dragTo(target);
     }
 }

--- a/tests/userProfile/AQA Prac/dragAndDrop.spec.ts
+++ b/tests/userProfile/AQA Prac/dragAndDrop.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from '@playwright/test';
+import { test } from '../../../src/fixtures/fixture_signIn';
+import { PageUrls, TestDataSignin } from '../../../src/testData/testData';
+test.describe('AQA Practice - Select Suite', () => {
+    test.beforeEach(async ({ userProfilePage, signInPage, aqaPractice }) => {
+        await signInPage.goto();
+        await signInPage.fillEmailAddress(TestDataSignin.EMAIL);
+        await signInPage.fillPasswordInput(TestDataSignin.PASSWORD);
+        await signInPage.submit();
+        await expect(userProfilePage.getPage()).toHaveURL(PageUrls.USER_PROFILE);
+        await aqaPractice.aqaPracticeDropdown.hover();
+        await aqaPractice.dragAndDropItem.click();
+        await expect(aqaPractice.getPage()).toHaveURL(PageUrls.DRAG_AND_DROP);
+    });
+    test('[AQAPRACT-583] Drag & Drop page elements validation', async ({ aqaPractice }) => {
+        await aqaPractice.backToProfileBtn.click();
+        await expect(aqaPractice.getPage()).toHaveURL(PageUrls.USER_PROFILE);
+        await aqaPractice.aqaPracticeDropdown.hover();
+        await aqaPractice.dragAndDropItem.click();
+        await expect(aqaPractice.getPage()).toHaveURL(PageUrls.DRAG_AND_DROP);
+        await expect(aqaPractice.sortResponsibilitiesTitle).toBeVisible();
+        await expect(aqaPractice.sortResponsibleSubtitle).toBeVisible();
+        await expect(aqaPractice.chipWriteTestCases).toBeVisible();
+        await expect(aqaPractice.chipTestingRequirements).toBeVisible();
+        await expect(aqaPractice.chipAutomationScripts).toBeVisible();
+        await expect(aqaPractice.chipFrameworkSetup).toBeVisible();
+        await expect(aqaPractice.manualWorkTitle).toBeVisible();
+        await expect(aqaPractice.automationWorkTitle).toBeVisible();
+        await expect(aqaPractice.finishDragButton).toHaveClass(/bg-\[#EFEFF0\]/);
+    });
+    test('[AQAPRACT-584] Redirection to the user profile after finishing course', async ({
+        aqaPractice,
+        userProfilePage,
+    }) => {
+        await aqaPractice.dragAndDrop(aqaPractice.chipWriteTestCases, aqaPractice.manualCol1);
+        await aqaPractice.dragAndDrop(aqaPractice.chipTestingRequirements, aqaPractice.manualCol2);
+        await aqaPractice.dragAndDrop(aqaPractice.chipAutomationScripts, aqaPractice.autoCol1);
+        await aqaPractice.dragAndDrop(aqaPractice.chipFrameworkSetup, aqaPractice.autoCol2);
+        await expect(aqaPractice.finishDragButton).toBeEnabled();
+        await aqaPractice.finishDragButton.click();
+        await expect(aqaPractice.congratulationPopup).toBeVisible();
+        await expect(userProfilePage.getPage()).toHaveURL(PageUrls.USER_PROFILE);
+    });
+    test('[AQAPRACT-585] Moving the Write test cases chips to the first column of the Manual Work section', async ({
+        aqaPractice,
+    }) => {
+        await aqaPractice.chipWriteTestCases.hover();
+        await expect(aqaPractice.chipWriteTestCases).toHaveClass(/hover:bg-sky-300/);
+        await aqaPractice.dragAndDrop(aqaPractice.chipWriteTestCases, aqaPractice.manualCol1);
+        await expect(aqaPractice.finishDragButton).toBeEnabled();
+    });
+    test('[AQAPRACT-586] Moving the Testing requirements chips to the first column on the second column of the Manual work', async ({
+        aqaPractice,
+    }) => {
+        await aqaPractice.chipTestingRequirements.hover();
+        await aqaPractice.dragAndDrop(aqaPractice.chipTestingRequirements, aqaPractice.manualCol2);
+        await expect(aqaPractice.manualCol2).toHaveClass(
+            'flex flex-col flex-1 items-center justify-center min-h-[200px] border border-dashed border-zinc-200 '
+        );
+        await expect(aqaPractice.finishDragButton).toHaveClass(/bg-\[#EFEFF0\]/);
+    });
+    test('[AQAPRACT-587] Moving Write automation scripts chip to the first column of the first column on the Automation work', async ({
+        aqaPractice,
+    }) => {
+        await aqaPractice.chipAutomationScripts.hover();
+        await aqaPractice.dragAndDrop(aqaPractice.chipAutomationScripts, aqaPractice.autoCol1);
+        await expect(aqaPractice.autoCol1).toHaveClass(
+            'flex flex-col flex-1 items-center justify-center min-h-[200px] border border-dashed border-zinc-200 '
+        );
+        await expect(aqaPractice.finishDragButton).toHaveClass(/bg-\[#EFEFF0\]/);
+    });
+    test('[AQAPRACT-588] Moving Framework set chip to the first column of the second column on the Automation work', async ({
+        aqaPractice,
+    }) => {
+        await aqaPractice.chipFrameworkSetup.hover();
+        await aqaPractice.dragAndDrop(aqaPractice.chipFrameworkSetup, aqaPractice.autoCol2);
+        await expect(aqaPractice.autoCol2).toHaveClass(
+            'flex flex-col flex-1 items-center justify-center min-h-[200px] border border-dashed border-zinc-200 '
+        );
+        await expect(aqaPractice.finishDragButton).toHaveClass(/bg-\[#EFEFF0\]/);
+    });
+    test('[AQAPRACT-589] Availability of the Finish button after transferring all chips', async ({
+        aqaPractice,
+    }) => {
+        await expect(aqaPractice.finishDragButton).toHaveClass(/bg-\[#EFEFF0\]/);
+        await aqaPractice.dragAndDrop(aqaPractice.chipWriteTestCases, aqaPractice.manualCol1);
+        await aqaPractice.dragAndDrop(aqaPractice.chipTestingRequirements, aqaPractice.manualCol2);
+        await aqaPractice.dragAndDrop(aqaPractice.chipAutomationScripts, aqaPractice.autoCol1);
+        await aqaPractice.dragAndDrop(aqaPractice.chipFrameworkSetup, aqaPractice.autoCol2);
+        await expect(aqaPractice.finishDragButton).toBeEnabled();
+        await aqaPractice.finishDragButton.click();
+        await expect(aqaPractice.congratulationPopup).toBeVisible();
+    });
+    test('[AQAPRACT-590] Moving chips to the wrong column', async ({ aqaPractice }) => {
+        await aqaPractice.dragAndDrop(aqaPractice.manualWorkTitle, aqaPractice.manualCol2);
+        await expect(aqaPractice.finishDragButton).toHaveClass(/bg-\[#EFEFF0\]/);
+    });
+});


### PR DESCRIPTION
Implemented test scenarios for Drag & Drop functionality in AQA Practice module.
Covered validation for:
- Hovering over chips
- Moving chips into valid and invalid columns
- Verifying chips stay in correct positions
- Added related locators and helper methods to AqaPractice page object.
- Ensured success message (Congratulations! Let's test for the best!) is displayed after finishing drag & drop.