### PR TITLE
API Suite: Auth API Test Cases Automation

### DIFF
--- a/src/pages/api/coursesApi.ts
+++ b/src/pages/api/coursesApi.ts
@@ -19,17 +19,18 @@ import { expect } from '@playwright/test';
 export class CoursesApi extends BaseApi {
     private token: string | null = null;
 
-    async registerUserApi(bodyData: RegisterDataDTO): Promise<void> {
-        await this.post<RegisterDataDTO, void>(AuthEndpoints.REGISTER_ENDP, bodyData, {
+    async registerUserApi(bodyData: RegisterDataDTO): Promise<SignInRegisterResponseDTO> {
+        return await this.post<RegisterDataDTO, SignInRegisterResponseDTO>(AuthEndpoints.REGISTER_ENDP, bodyData, {
             'Content-Type': 'application/json',
         });
     }
-    async signInUserApi(bodyData: SignInRequestDTO): Promise<void> {
+    async signInUserApi(bodyData: SignInRequestDTO): Promise<SignInRegisterResponseDTO> {
         const response = await this.post<SignInRequestDTO, SignInRegisterResponseDTO>(
             AuthEndpoints.SIGNIN_ENDP,
             bodyData
         );
         this.token = response['jwt-token'];
+        return response
     }
 
     getAuthHeader(): Record<string, string> {

--- a/tests/api/authTest.spec.ts
+++ b/tests/api/authTest.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from '@playwright/test';
+import { test } from '../../src/fixtures/api/baseApi_fixture';
+import { generateUniqueEmail, TestData, TestDataSignin } from '../../src/testData/testData';
+
+test.describe('Auth Suite', () => {
+    let email: string;
+    test.beforeEach(() => {
+        email = generateUniqueEmail();
+    });
+
+    test('[] Register', async ({ coursesApi }) => {
+        const bodyData = {
+            firstName: TestData.FIRSTNAME,
+            lastName: TestData.LASTNAME,
+            email,
+            dateOfBirth: TestData.DATE_OF_BIRTH,
+            password: TestData.PASSWORD,
+        };
+
+        const response = await coursesApi.registerUserApi(bodyData);
+        await coursesApi.verifyResponseTruthy(response);
+        expect(response).toHaveProperty('jwt-token');
+    });
+
+    test('[] Login', async ({ coursesApi }) => {
+        const bodyData = {
+            email: TestDataSignin.EMAIL,
+            password: TestDataSignin.PASSWORD,
+        };
+        const response = await coursesApi.signInUserApi(bodyData);
+        await coursesApi.verifyResponseTruthy(response);
+        expect(response).toHaveProperty('jwt-token');
+    });
+});

--- a/tests/api/authTest.spec.ts
+++ b/tests/api/authTest.spec.ts
@@ -8,7 +8,7 @@ test.describe('Auth Suite', () => {
         email = generateUniqueEmail();
     });
 
-    test('[] Register', async ({ coursesApi }) => {
+    test('[AQAPRACT-612] User registration with valid data', async ({ coursesApi }) => {
         const bodyData = {
             firstName: TestData.FIRSTNAME,
             lastName: TestData.LASTNAME,
@@ -22,7 +22,7 @@ test.describe('Auth Suite', () => {
         expect(response).toHaveProperty('jwt-token');
     });
 
-    test('[] Login', async ({ coursesApi }) => {
+    test('[AQAPRACT-611] Log in with valid data', async ({ coursesApi }) => {
         const bodyData = {
             email: TestDataSignin.EMAIL,
             password: TestDataSignin.PASSWORD,

--- a/tests/api/authTest.spec.ts
+++ b/tests/api/authTest.spec.ts
@@ -3,16 +3,11 @@ import { test } from '../../src/fixtures/api/baseApi_fixture';
 import { generateUniqueEmail, TestData, TestDataSignin } from '../../src/testData/testData';
 
 test.describe('Auth Suite', () => {
-    let email: string;
-    test.beforeEach(() => {
-        email = generateUniqueEmail();
-    });
-
     test('[AQAPRACT-612] User registration with valid data', async ({ coursesApi }) => {
         const bodyData = {
             firstName: TestData.FIRSTNAME,
             lastName: TestData.LASTNAME,
-            email,
+            email: generateUniqueEmail(),
             dateOfBirth: TestData.DATE_OF_BIRTH,
             password: TestData.PASSWORD,
         };


### PR DESCRIPTION
This PR adds new Auth Suite tests using Playwright.
[AQAPRACT-612] Verify user registration with valid data
[AQAPRACT-611] Verify user login with valid data

What was done:
- Added test for registerUserApi
- Added test for signInUserApi
- Implemented generateUniqueEmail() for unique emails
- Checked presence of jwt-token in the response
- Used verifyResponseTruthy to validate successful responses