### PR TITLE
Ziyaret/auth/healthcheck

### DIFF
--- a/src/pages/api/coursesApi.ts
+++ b/src/pages/api/coursesApi.ts
@@ -126,10 +126,7 @@ export class CoursesApi extends BaseApi {
     //! Healt Check Methods
     async getHealtCheck(endpoint: string, hasToken: boolean): Promise<string> {
         const headers = hasToken ? this.getAuthHeader() : undefined;
-        const response = await this.request.get(
-            `${this.baseUrl}${endpoint}`,
-            { headers }
-        );
+        const response = await this.request.get(`${this.baseUrl}${endpoint}`, { headers });
         return await response.text();
     }
 }

--- a/src/pages/api/coursesApi.ts
+++ b/src/pages/api/coursesApi.ts
@@ -13,16 +13,25 @@ import {
     UserPhotoResponseDTO,
     UserProfilesResponseDTO,
 } from '../../dto/authDTO';
-import { AuthEndpoints, CourseEndpoints, UserProfilesEndpoints } from '../../testData/testData';
+import {
+    AuthEndpoints,
+    CourseEndpoints,
+    HealthCheckEndpoints,
+    UserProfilesEndpoints,
+} from '../../testData/testData';
 import { expect } from '@playwright/test';
 
 export class CoursesApi extends BaseApi {
     private token: string | null = null;
 
     async registerUserApi(bodyData: RegisterDataDTO): Promise<SignInRegisterResponseDTO> {
-        return await this.post<RegisterDataDTO, SignInRegisterResponseDTO>(AuthEndpoints.REGISTER_ENDP, bodyData, {
-            'Content-Type': 'application/json',
-        });
+        return await this.post<RegisterDataDTO, SignInRegisterResponseDTO>(
+            AuthEndpoints.REGISTER_ENDP,
+            bodyData,
+            {
+                'Content-Type': 'application/json',
+            }
+        );
     }
     async signInUserApi(bodyData: SignInRequestDTO): Promise<SignInRegisterResponseDTO> {
         const response = await this.post<SignInRequestDTO, SignInRegisterResponseDTO>(
@@ -30,7 +39,7 @@ export class CoursesApi extends BaseApi {
             bodyData
         );
         this.token = response['jwt-token'];
-        return response
+        return response;
     }
 
     getAuthHeader(): Record<string, string> {
@@ -112,5 +121,15 @@ export class CoursesApi extends BaseApi {
 
     async deleteUserAccount(): Promise<void> {
         await this.delete<void>(UserProfilesEndpoints.DELETE_ACCOUNT_ENDP, this.getAuthHeader());
+    }
+
+    //! Healt Check Methods
+    async getHealtCheck(endpoint: string, hasToken: boolean): Promise<string> {
+        const headers = hasToken ? this.getAuthHeader() : undefined;
+        const response = await this.request.get(
+            `${this.baseUrl}${endpoint}`,
+            { headers }
+        );
+        return await response.text();
     }
 }

--- a/src/testData/testData.ts
+++ b/src/testData/testData.ts
@@ -51,3 +51,7 @@ export enum AuthEndpoints {
     REGISTER_ENDP = '/api/public/registration',
     SIGNIN_ENDP = '/api/public/login',
 }
+export enum HealthCheckEndpoints {
+    HEALTH_CHECK_SECURED = '/api/secured/health',
+    HEALTH_CHECK_PUBLIC = '/api/public/health',
+}

--- a/tests/api/healthCheck.spec.ts
+++ b/tests/api/healthCheck.spec.ts
@@ -5,11 +5,17 @@ import { HealthCheckEndpoints, TestDataSignin } from '../../src/testData/testDat
 test.describe('API / Health Check Suite', () => {
     test('[AQAPRACT-612] Get healthcheck for /api/secured service', async ({ coursesApi }) => {
         await coursesApi.ensureUserSignedIn(TestDataSignin.EMAIL, TestDataSignin.PASSWORD);
-        const response = await coursesApi.getHealtCheck(HealthCheckEndpoints.HEALTH_CHECK_SECURED, true);
+        const response = await coursesApi.getHealtCheck(
+            HealthCheckEndpoints.HEALTH_CHECK_SECURED,
+            true
+        );
         expect(response).toBe('OK');
     });
     test('[AQAPRACT-613] Get healthcheck for /api/public service', async ({ coursesApi }) => {
-        const response = await coursesApi.getHealtCheck(HealthCheckEndpoints.HEALTH_CHECK_PUBLIC, false);
+        const response = await coursesApi.getHealtCheck(
+            HealthCheckEndpoints.HEALTH_CHECK_PUBLIC,
+            false
+        );
         expect(response).toBe('OK');
     });
 });

--- a/tests/api/healthCheck.spec.ts
+++ b/tests/api/healthCheck.spec.ts
@@ -1,0 +1,15 @@
+import { expect } from '@playwright/test';
+import { test } from '../../src/fixtures/api/baseApi_fixture';
+import { HealthCheckEndpoints, TestDataSignin } from '../../src/testData/testData';
+
+test.describe('API / Health Check Suite', () => {
+    test('[secured]', async ({ coursesApi }) => {
+        await coursesApi.ensureUserSignedIn(TestDataSignin.EMAIL, TestDataSignin.PASSWORD);
+        const response = await coursesApi.getHealtCheck(HealthCheckEndpoints.HEALTH_CHECK_SECURED, true);
+        expect(response).toBe('OK');
+    });
+    test('[public]', async ({ coursesApi }) => {
+        const response = await coursesApi.getHealtCheck(HealthCheckEndpoints.HEALTH_CHECK_PUBLIC, false);
+        expect(response).toBe('OK');
+    });
+});

--- a/tests/api/healthCheck.spec.ts
+++ b/tests/api/healthCheck.spec.ts
@@ -3,12 +3,12 @@ import { test } from '../../src/fixtures/api/baseApi_fixture';
 import { HealthCheckEndpoints, TestDataSignin } from '../../src/testData/testData';
 
 test.describe('API / Health Check Suite', () => {
-    test('[secured]', async ({ coursesApi }) => {
+    test('[AQAPRACT-612] Get healthcheck for /api/secured service', async ({ coursesApi }) => {
         await coursesApi.ensureUserSignedIn(TestDataSignin.EMAIL, TestDataSignin.PASSWORD);
         const response = await coursesApi.getHealtCheck(HealthCheckEndpoints.HEALTH_CHECK_SECURED, true);
         expect(response).toBe('OK');
     });
-    test('[public]', async ({ coursesApi }) => {
+    test('[AQAPRACT-613] Get healthcheck for /api/public service', async ({ coursesApi }) => {
         const response = await coursesApi.getHealtCheck(HealthCheckEndpoints.HEALTH_CHECK_PUBLIC, false);
         expect(response).toBe('OK');
     });


### PR DESCRIPTION
Implemented separate API tests for both secured and public health check endpoints. Updated getHealthCheck() method to support authenticated and unauthenticated requests.

Changes Made:
- Added [secured] and [public] test cases in healthCheck.spec.ts
- Updated getHealthCheck() in CoursesApi to accept an optional hasToken flag
- Ensured proper header handling (authorization header only when required)
- Verified both endpoints return status 200 and body 'OK'
